### PR TITLE
Add support for new driver discovery mechanism.

### DIFF
--- a/intake_s3_manifests/__init__.py
+++ b/intake_s3_manifests/__init__.py
@@ -3,6 +3,8 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
+import intake  # Import this first to avoid circular imports during discovery.
+del intake
 from .s3_manifest import S3ManifestSource
 
 import intake.container

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ setup(
     license='BSD',
     py_modules=['intake_s3_manifests'],
     packages=find_packages(),
+    entry_points={
+        'intake.drivers': [
+            's3_manifest = intake_s3_manifests.s3_manifest:S3ManifestSource',
+        ]},
     package_data={'': ['*.csv', '*.yml', '*.html']},
     include_package_data=True,
     install_requires=requires,

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,11 @@
+import intake
+import pytest
+
+
+def test_discovery():
+    with pytest.warns(None) as record:
+        registry = intake.autodiscover()
+    # For awhile we expect a PendingDeprecationWarning due to
+    # do_pacakge_scan=True. But we should *not* get a FutureWarning.
+    for record in record.list:
+        assert not isinstance(record.message, FutureWarning)


### PR DESCRIPTION
See intake/intake#236 and intake/intake#392.

If you have questions about the circular import avoidance noted in the code
comment here, see intake/intake#405. The short version is: the old driver
discovery mechanism could fail silently in certain situations, and the new
discovery mechanism would fail with an exception. This change ensures that
either mechanism will succeed.